### PR TITLE
separate body and formData when parsing parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,17 @@ module.exports = convert;
 function convert(parameters) {
   var parametersSchema = {};
   var bodySchema = getBodySchema(parameters);
+  var formDataSchema = getSchema(parameters, 'formData');
   var headerSchema = getSchema(parameters, 'header');
   var pathSchema = getSchema(parameters, 'path');
   var querySchema = getSchema(parameters, 'query');
 
   if (bodySchema) {
     parametersSchema.body = bodySchema;
+  }
+
+  if (formDataSchema) {
+    parametersSchema.formData = formDataSchema;
   }
 
   if (headerSchema) {
@@ -67,8 +72,6 @@ function getBodySchema(parameters) {
 
   if (bodySchema) {
     bodySchema = bodySchema.schema;
-  } else {
-    bodySchema = getSchema(parameters, 'formData');
   }
 
   return bodySchema;

--- a/test/data-driven/allow-a-single-formData-param.js
+++ b/test/data-driven/allow-a-single-formData-param.js
@@ -1,0 +1,21 @@
+module.exports = {
+  parameters: [
+    {
+      in: 'formData',
+      name: 'wowow',
+      schema: {
+        $ref: 'foo'
+      },
+      required: true
+    }
+  ],
+
+  outputSchema: {
+    formData: {
+      properties: {
+        wowow: {}
+      },
+      required: ['wowow']
+    }
+  }
+};


### PR DESCRIPTION
Hi !

I'm not sure it's a bug when adding a parameter to openApi in `"formData"`, when I set `required` to `true`, it fails with a message telling me that said field is required in `body`.

I've separated formData and body from this lib, along with express-openapi-validation (which uses this lib too).

I would be happy to hear any explanation about why body and formData were merged, if it was on purpose.

Posting a PR also on express-openapi-validation repo.

Thank you!
