### PR TITLE
Allow Custom Parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function copyValidationKeywords(src, dst) {
     for (var i = 0, keys = Object.keys(src), len = keys.length; i < len; i++) {
       var keyword = keys[i];
 
-      if (VALIDATION_KEYWORDS.indexOf(keyword) > -1) {
+      if (VALIDATION_KEYWORDS.indexOf(keyword) > -1 || keyword.slice(0,2) === 'x-') {
         dst[keyword] = src[keyword];
       }
     }

--- a/test/data-driven/allow-custom-parameters.js
+++ b/test/data-driven/allow-custom-parameters.js
@@ -1,0 +1,22 @@
+module.exports = {
+  parameters: [
+    {
+      in: 'query',
+      name: 'search',
+      type: 'string',
+      'x-custom': 'value'
+    }
+  ],
+
+  outputSchema: {
+    query: {
+      properties: {
+        search: {
+          type: 'string',
+          'x-custom': 'value'
+        }
+      },
+      required: []
+    }
+  }
+};


### PR DESCRIPTION
Custom parameters can be extremely useful to do additional processing, like type coercion.  The commonly used AJV library has support for this through [custom keywords](https://www.npmjs.com/package/ajv#defining-custom-keywords).

Swagger convention for [custom extensions](https://swagger.io/docs/specification/openapi-extensions/) is to prefix them with `x-`.

Check for the custom extension prefix and pass them through.